### PR TITLE
Basic player movement

### DIFF
--- a/ShooterCrateBoxProject/Assets/Game/Prefabs/CratePickup.prefab
+++ b/ShooterCrateBoxProject/Assets/Game/Prefabs/CratePickup.prefab
@@ -12,7 +12,7 @@ GameObject:
   - component: {fileID: 9158793818279407442}
   - component: {fileID: 3594259743682911603}
   - component: {fileID: 8575356579069666274}
-  m_Layer: 0
+  m_Layer: 8
   m_Name: CratePickup
   m_TagString: Untagged
   m_Icon: {fileID: 5721338939258241955, guid: 0000000000000000d000000000000000, type: 0}
@@ -56,7 +56,7 @@ BoxCollider2D:
   m_Enabled: 1
   m_Density: 1
   m_Material: {fileID: 0}
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
   m_Offset: {x: 0, y: 0}

--- a/ShooterCrateBoxProject/Assets/Game/Prefabs/Enemies/EnemyBase.prefab
+++ b/ShooterCrateBoxProject/Assets/Game/Prefabs/Enemies/EnemyBase.prefab
@@ -62,7 +62,6 @@ GameObject:
   m_Component:
   - component: {fileID: 8707810739202686602}
   - component: {fileID: 6587613307767262822}
-  - component: {fileID: -2143784746841049907}
   m_Layer: 0
   m_Name: EnemyBase
   m_TagString: Untagged
@@ -107,16 +106,3 @@ Rigidbody2D:
   m_SleepingMode: 1
   m_CollisionDetection: 1
   m_Constraints: 4
---- !u!114 &-2143784746841049907
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 8830442599775718791}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 00c27cee6cd958e47b1577b42d5aabdd, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  rb2D: {fileID: 0}

--- a/ShooterCrateBoxProject/Assets/Game/Prefabs/Player.prefab
+++ b/ShooterCrateBoxProject/Assets/Game/Prefabs/Player.prefab
@@ -84,6 +84,112 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!1 &1898209734184124190
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1820621472742150052}
+  - component: {fileID: 9047966302961747593}
+  m_Layer: 0
+  m_Name: WallSensorRight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1820621472742150052
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1898209734184124190}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.25, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2015153983868497171}
+  m_RootOrder: 3
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &9047966302961747593
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1898209734184124190}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6a9587a8baf6b1f45a59cb1500a4e08d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SensorShape: 1
+  SenseTag: 0
+  active: 0
+  layerToSense:
+    serializedVersion: 2
+    m_Bits: 1
+  radius: 0.24
+  rectangleSize: {x: 0.05, y: 0.9}
+  tagToSense: 
+--- !u!1 &2529580363227584827
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 813706189725332863}
+  - component: {fileID: 1409014338760864344}
+  m_Layer: 0
+  m_Name: WallSensorLeft
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &813706189725332863
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2529580363227584827}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.25, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2015153983868497171}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1409014338760864344
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2529580363227584827}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6a9587a8baf6b1f45a59cb1500a4e08d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  SensorShape: 1
+  SenseTag: 0
+  active: 0
+  layerToSense:
+    serializedVersion: 2
+    m_Bits: 1
+  radius: 0.24
+  rectangleSize: {x: 0.05, y: 0.9}
+  tagToSense: 
 --- !u!1 &2674786124721267973
 GameObject:
   m_ObjectHideFlags: 0
@@ -128,7 +234,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 00c27cee6cd958e47b1577b42d5aabdd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  acceleration: 56.25
+  currentVelocityX: 0
+  deceleration: 112.5
+  maxVelocityX: 5.625
   rb2D: {fileID: 1215762869519165064}
+  useAcceleration: 1
+  useDeceleration: 1
+  wallSensorLeft: {fileID: 1409014338760864344}
+  wallSensorRight: {fileID: 9047966302961747593}
 --- !u!1 &3886328265422904727
 GameObject:
   m_ObjectHideFlags: 0
@@ -249,7 +363,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 5330366557994720466}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: -0.275, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -273,8 +387,8 @@ MonoBehaviour:
   active: 0
   layerToSense:
     serializedVersion: 2
-    m_Bits: 0
-  radius: 0
+    m_Bits: 1
+  radius: 0.24
   rectangleSize: {x: 0, y: 0}
   tagToSense: 
 --- !u!1 &5333498625780924230
@@ -307,6 +421,8 @@ Transform:
   m_Children:
   - {fileID: 4192250688171665129}
   - {fileID: 3121377879012565239}
+  - {fileID: 813706189725332863}
+  - {fileID: 1820621472742150052}
   m_Father: {fileID: 2460279064761382847}
   m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -446,7 +562,18 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 2a29abb4d488a6a459a6facfe76749eb, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  cancelRate: 200
+  gravityScale: 5.5
+  groundSensor: {fileID: 1585363905880020236}
+  headSensor: {fileID: 5042706002487015526}
+  jumpCount: 0
+  jumpForce: 0
+  jumpWindowTime: 0.5
+  maxJumpHeight: 4
+  multiJump: 0
   rb2D: {fileID: 1215762869519165064}
+  totalJumps: 1
+  variableJump: 1
 --- !u!1 &8476635956399915918
 GameObject:
   m_ObjectHideFlags: 0
@@ -472,7 +599,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8476635956399915918}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0.275, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -496,8 +623,8 @@ MonoBehaviour:
   active: 0
   layerToSense:
     serializedVersion: 2
-    m_Bits: 0
-  radius: 0
+    m_Bits: 1
+  radius: 0.24
   rectangleSize: {x: 0, y: 0}
   tagToSense: 
 --- !u!1 &8576693537728502467

--- a/ShooterCrateBoxProject/Assets/Scenes/Main.unity
+++ b/ShooterCrateBoxProject/Assets/Scenes/Main.unity
@@ -263,9 +263,9 @@ RectTransform:
   m_Father: {fileID: 727369453}
   m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 217.5, y: -22.5}
   m_SizeDelta: {x: 35, y: 35}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &100325507
@@ -1286,7 +1286,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 1
+  m_IsActive: 0
 --- !u!114 &565201238
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1334,7 +1334,7 @@ Canvas:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 565201237}
-  m_Enabled: 0
+  m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 0
   m_Camera: {fileID: 0}
@@ -1985,6 +1985,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3796288531980197520, guid: 4a0e05208d49df44daa5bc6a734f5907, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4a0e05208d49df44daa5bc6a734f5907, type: 3}
 --- !u!1 &706108536
@@ -2062,7 +2066,19 @@ MonoBehaviour:
     m_ActionId: b1d7b278-5041-45ed-83d7-64252779c438
     m_ActionName: Gameplay/Jump
   - m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 706108539}
+        m_TargetAssemblyTypeName: PlayerController, Assembly-CSharp
+        m_MethodName: OnMoveInput
+        m_Mode: 0
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
     m_ActionId: e581c5d2-7798-409f-a08b-95b6d2b26f96
     m_ActionName: Gameplay/Move
   - m_PersistentCalls:
@@ -2331,9 +2347,9 @@ RectTransform:
   m_Father: {fileID: 1836283934}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 80, y: -70}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &812278125
@@ -2588,9 +2604,9 @@ RectTransform:
   m_Father: {fileID: 2084489179}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 80, y: -70}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &878156692
@@ -2788,9 +2804,9 @@ RectTransform:
   m_Father: {fileID: 1836283934}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 80, y: -15}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &887668442
@@ -3063,6 +3079,10 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 3599956792499333458, guid: f1a48abb34bd2d143898def84e34e552, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f1a48abb34bd2d143898def84e34e552, type: 3}
 --- !u!1001 &1016394923
@@ -3072,6 +3092,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 0}
     m_Modifications:
+    - target: {fileID: 778191573315729387, guid: d5bfb995bc8ef2a4a988c5bf355d6708, type: 3}
+      propertyPath: m_Enabled
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1165118964071480748, guid: d5bfb995bc8ef2a4a988c5bf355d6708, type: 3}
       propertyPath: m_RootOrder
       value: 3
@@ -3268,9 +3292,9 @@ RectTransform:
   m_Father: {fileID: 2084489179}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 80, y: -15}
   m_SizeDelta: {x: 160, y: 30}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1048834413
@@ -4255,9 +4279,9 @@ RectTransform:
   m_Father: {fileID: 727369453}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 137.5, y: -22.5}
   m_SizeDelta: {x: 35, y: 35}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1627109143
@@ -4746,9 +4770,9 @@ RectTransform:
   m_Father: {fileID: 1169459097}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 192.5, y: -25}
   m_SizeDelta: {x: 155, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1926532022
@@ -5016,9 +5040,9 @@ RectTransform:
   m_Father: {fileID: 727369453}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 57.5, y: -22.5}
   m_SizeDelta: {x: 115, y: 45}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2016880573
@@ -5151,9 +5175,9 @@ RectTransform:
   m_Father: {fileID: 1169459097}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 52.5, y: -25}
   m_SizeDelta: {x: 105, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2018165917
@@ -5589,9 +5613,9 @@ RectTransform:
   m_Father: {fileID: 727369453}
   m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 177.5, y: -22.5}
   m_SizeDelta: {x: 35, y: 35}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &2078606554

--- a/ShooterCrateBoxProject/Assets/Scripts/Control/PlayerController.cs
+++ b/ShooterCrateBoxProject/Assets/Scripts/Control/PlayerController.cs
@@ -19,11 +19,20 @@ public class PlayerController : MonoBehaviour
 
     public void OnJumpInput(InputAction.CallbackContext context)
     {
-        
+        // True on first frame jump input is pressed.
+        if (context.started)
+        {
+            player.Jumper2D.Jump();
+        }
+        // True on the first frame the jump input is released.
+        else if (context.canceled)
+        {
+            player.Jumper2D.StopVariableJump();
+        }
     }
 
     public void OnMoveInput(InputAction.CallbackContext context)
     {
-
+        player.Mover2D.MoveInput = context.ReadValue<float>();
     }
 }

--- a/ShooterCrateBoxProject/Assets/Scripts/Editor/Jumper2DEditor.cs
+++ b/ShooterCrateBoxProject/Assets/Scripts/Editor/Jumper2DEditor.cs
@@ -1,0 +1,314 @@
+using UnityEngine;
+using UnityEditor;
+
+/// <summary>
+/// Custom editor class for the Jumper2D object. Allows designers to design and
+/// test jumping behaviour with a variety of tools.
+/// </summary>
+[CustomEditor(typeof(Jumper2D))]
+[CanEditMultipleObjects]
+public class Jumper2DEditor : Editor
+{
+    /// <summary>
+    /// Represents the Jumper2D's cancelRate property.
+    /// </summary>
+    private SerializedProperty cancelRateProperty;
+
+    /// <summary>
+    /// Represents the Jumper2D's gravityScale property.
+    /// </summary>
+    private SerializedProperty gravityScaleProperty;
+
+    /// <summary>
+    /// Sensor2D responsible for checking the grounded state of the object.
+    /// </summary>
+    private SerializedProperty groundSensorProperty;
+
+    /// <summary>
+    /// Sensor2D responsible for checking collisions above the player.
+    /// </summary>
+    private SerializedProperty headSensorProperty;
+
+    /// <summary>
+    /// Represents the Jumper2D's jumpCount property.
+    /// </summary>
+    private SerializedProperty jumpCountProperty;
+
+    /// <summary>
+    /// Represents the Jumper2D's jumpWindowTime property.
+    /// </summary>
+    private SerializedProperty jumpWindowTimeProperty;
+
+    /// <summary>
+    /// Represents the Jumper2D's maxJumpHeight property.
+    /// </summary>
+    private SerializedProperty maxJumpHeightProperty;
+
+    /// <summary>
+    /// Represents the Jumper2D's multiJump property.
+    /// </summary>
+    private SerializedProperty multiJumpProperty;
+
+    /// <summary>
+    /// Represents the Jumper2D's rb2D property.
+    /// </summary>
+    private SerializedProperty rb2DProperty;
+
+    /// <summary>
+    /// Represents the Jumper2D's totalJumps property.
+    /// </summary>
+    private SerializedProperty totalJumpsProperty;
+
+    /// <summary>
+    /// If true, final jump height is higher the longer the player holds down 
+    /// jump input, clamped at maxJumpHeight. If false, player always jumps to
+    /// maxJumpHeight when jump input is pressed.
+    /// </summary>
+    private SerializedProperty variableJumpProperty;
+
+    /// <summary>
+    /// Should info be displayed in the editor?
+    /// </summary>
+    private static bool showInfo = true;
+
+    /// <summary>
+    /// Should jump parameter presets be displayed in the editor?
+    /// </summary>
+    private static bool showPresets = false;
+
+    /// <summary>
+    /// Should testing controls be displayed in the editor?
+    /// </summary>
+    private static bool showTesting = false;
+
+    #region Editor Methods
+    private void OnEnable()
+    {
+        cancelRateProperty = serializedObject.FindProperty("cancelRate");
+        gravityScaleProperty = serializedObject.FindProperty("gravityScale");
+        groundSensorProperty = serializedObject.FindProperty("groundSensor");
+        headSensorProperty = serializedObject.FindProperty("headSensor");
+        jumpCountProperty = serializedObject.FindProperty("jumpCount");
+        jumpWindowTimeProperty = serializedObject.FindProperty("jumpWindowTime");
+        maxJumpHeightProperty = serializedObject.FindProperty("maxJumpHeight");
+        multiJumpProperty = serializedObject.FindProperty("multiJump");
+        rb2DProperty = serializedObject.FindProperty("rb2D");
+        totalJumpsProperty = serializedObject.FindProperty("totalJumps");
+        variableJumpProperty = serializedObject.FindProperty("variableJump");
+    }
+
+    public override void OnInspectorGUI()
+    {
+        Jumper2D jumper2D = target as Jumper2D;
+
+        // Displays the script name at the top of the inspector GUI, which
+        // mimics Unity-standard format.
+        using (new EditorGUI.DisabledScope(true))
+            EditorGUILayout.ObjectField("Script", 
+            MonoScript.FromMonoBehaviour((MonoBehaviour)target), 
+            GetType(), false);
+
+        DrawComponentReferences();
+
+        EditorGUILayout.Space();
+        DrawJumpParams();
+
+        if (multiJumpProperty.boolValue)
+        {
+            DrawMultiJumpParams();
+        }
+
+        if (variableJumpProperty.boolValue)
+        {
+            DrawVariableJumpParams();
+        }
+
+        EditorGUILayout.Space();
+        showPresets = EditorGUILayout.Foldout(showPresets, "Presets");
+        if (showPresets)
+        {
+            DrawPresets();
+        }
+
+        showTesting = EditorGUILayout.Foldout(showTesting,
+            "Editor Testing");
+        if (showTesting)
+        {
+            DrawTesting(jumper2D);
+        }
+
+        showInfo = EditorGUILayout.Foldout(showInfo, "Info");
+        if (showInfo)
+        {
+            DrawInfo();
+        }
+
+        serializedObject.ApplyModifiedProperties();
+    }
+    #endregion
+
+    /// <summary>
+    /// Draws Component References section of the custom editor window.
+    /// </summary>
+    private void DrawComponentReferences()
+    {
+        EditorGUILayout.LabelField("Component References",
+            EditorStyles.boldLabel);
+
+        EditorGUILayout.PropertyField(rb2DProperty,
+            new GUIContent("Rb 2D",
+            "Which Rigidbody2D should this Jumper2D affect?"));
+
+        EditorGUILayout.PropertyField(groundSensorProperty,
+            new GUIContent("Ground Sensor",
+            "Which Sensor2D should be used to check the grounded state?"));
+
+        EditorGUILayout.PropertyField(headSensorProperty,
+            new GUIContent("Head Sensor",
+            "Which Sensor2D should be used to check if the Jumper2D has hit " +
+            "a ceiling?"));
+    }
+
+    /// <summary>
+    /// Draws the Info section of the custom editor window.
+    /// </summary>
+    private void DrawInfo()
+    {
+        // Jump Hang Time
+        float gravity = Physics2D.gravity.y * gravityScaleProperty.floatValue;
+        float totalJumpTime = 2 *
+            Mathf.Sqrt((-2 * maxJumpHeightProperty.floatValue) / gravity);
+        using (new EditorGUI.DisabledScope(true))
+            EditorGUILayout.FloatField("Total Jump Time", totalJumpTime);
+
+        // Jump Frames
+        float jumpFrames = totalJumpTime / Time.fixedDeltaTime;
+        float standardJumpFrames = UtilityMethods.StandardizeFrameCount(jumpFrames, 60);
+        using (new EditorGUI.DisabledScope(true))
+            EditorGUILayout.FloatField("Total Jump Frames (60fps)", standardJumpFrames);
+
+        // Remaining Jumps
+        if (multiJumpProperty.boolValue)
+        {
+            int remainingJumps =
+                totalJumpsProperty.intValue - jumpCountProperty.intValue;
+            using (new EditorGUI.DisabledScope(true))
+                EditorGUILayout.FloatField("Jumps Remaining", remainingJumps);
+        }
+    }
+
+    /// <summary>
+    /// Draws Jump Parameters section of the custom editor window.
+    /// </summary>
+    private void DrawJumpParams()
+    {
+        EditorGUILayout.LabelField("Jump Parameters", EditorStyles.boldLabel);
+
+        EditorGUILayout.PropertyField(maxJumpHeightProperty,
+            new GUIContent("Max Jump Height", 
+            "How high should it be allowed to jump?"));
+
+        EditorGUILayout.PropertyField(gravityScaleProperty,
+            new GUIContent("Gravity Scale", 
+            "How many times should gravity act per frame?"));
+            
+        EditorGUILayout.PropertyField(multiJumpProperty,
+            new GUIContent("Multi Jump", "Can it jump while in the air?"));
+
+        EditorGUILayout.PropertyField(variableJumpProperty,
+            new GUIContent("Variable Jump", 
+            "Should the jump cancel if input is released?"));
+    }
+
+    /// <summary>
+    /// Draws Multi Jump Parameters section of the custom editor window.
+    /// </summary>
+    private void DrawMultiJumpParams()
+    {
+        EditorGUILayout.Space();
+        EditorGUILayout.LabelField("Multi Jump Parameters", EditorStyles.boldLabel);
+        EditorGUILayout.PropertyField(totalJumpsProperty,
+            new GUIContent("Total Jumps", "How many times can it jump?"));
+    }
+
+    /// <summary>
+    /// Draws the Presets section of the custom editor window.
+    /// </summary>
+    private void DrawPresets()
+    {
+        EditorGUILayout.LabelField("Use these buttons to set jump " +
+                    "behaviour to the selected description.");
+
+        if (GUILayout.Button(new GUIContent("Midweight and Precise", 
+            "i.e Celeste")))
+        {
+            maxJumpHeightProperty.floatValue = 2.0f;
+            gravityScaleProperty.floatValue = 4.53051f;
+            multiJumpProperty.boolValue = false;
+            variableJumpProperty.boolValue = false;
+        }
+        if (GUILayout.Button(new GUIContent("Lightweight and Floaty", 
+            "i.e. Super Meat Boy")))
+        {
+            maxJumpHeightProperty.floatValue = 5.0f;
+            gravityScaleProperty.floatValue = 4.075f;
+            multiJumpProperty.boolValue = false;
+            variableJumpProperty.boolValue = true;
+            cancelRateProperty.floatValue = 50.0f;
+
+        }
+        if (GUILayout.Button(new GUIContent("Heavy and Leaden", 
+            "i.e. Unravel")))
+        {
+            maxJumpHeightProperty.floatValue = 1.5f;
+            gravityScaleProperty.floatValue = 3.8f;
+            multiJumpProperty.boolValue = false;
+            variableJumpProperty.boolValue = false;
+        }
+    }
+
+    /// <summary>
+    /// Draws Testing section of the custom editor window.
+    /// </summary>
+    /// <param name="jumper2D">Jumper2D to test.</param> 
+    private static void DrawTesting(Jumper2D jumper2D)
+    {
+        EditorGUILayout.LabelField("While in Play Mode, use these buttons " + 
+            "to test jump behaviour.");
+        EditorGUILayout.LabelField("Best to keep jumpWindowTime >= 1 for " + 
+            "editor testing.");
+
+        if (GUILayout.Button("Jump"))
+        {
+            if (Application.isPlaying)
+            {
+                jumper2D.Jump();
+            }
+        }
+        if (GUILayout.Button("Stop Variable Jump"))
+        {
+            if (Application.isPlaying)
+            {
+                jumper2D.StopVariableJump();
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws Variable Jump Parameters section of the custom editor window.
+    /// </summary>
+    private void DrawVariableJumpParams()
+    {
+        EditorGUILayout.Space();
+        EditorGUILayout.LabelField("Variable Jump Parameters", 
+            EditorStyles.boldLabel);
+
+        EditorGUILayout.PropertyField(cancelRateProperty,
+            new GUIContent("Cancel Rate", "How quickly should the jump " + 
+            "cancel? If set to 0, jump will cancel instantly."));
+
+        EditorGUILayout.PropertyField(jumpWindowTimeProperty,
+            new GUIContent("Jump Window Time", "How long before it stops " + 
+            "checking for a released jump input?"));
+    }
+}

--- a/ShooterCrateBoxProject/Assets/Scripts/Editor/Jumper2DEditor.cs.meta
+++ b/ShooterCrateBoxProject/Assets/Scripts/Editor/Jumper2DEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b023ca384b9a1f54999e1d544e4ebfc9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ShooterCrateBoxProject/Assets/Scripts/Editor/Mover2DEditor.cs
+++ b/ShooterCrateBoxProject/Assets/Scripts/Editor/Mover2DEditor.cs
@@ -1,0 +1,329 @@
+using UnityEngine;
+using UnityEditor;
+
+/// <summary>
+/// Custom editor class for the Mover2D object. Allows designers to design and
+/// test movement behaviour with a variety of tools.
+/// </summary>
+[CustomEditor(typeof(Mover2D))]
+[CanEditMultipleObjects]
+public class Mover2DEditor : Editor
+{
+    /// <summary>
+    /// Represents the Mover2D's acceleration property.
+    /// </summary>
+    private SerializedProperty accelerationProperty;
+
+    /// <summary>
+    /// Represents the Mover2D's current X velocity.
+    /// </summary>
+    private SerializedProperty currentVelocityXProperty;
+
+    /// <summary>
+    /// Represents the Mover2D's deceleration property.
+    /// </summary>
+    private SerializedProperty decelerationProperty;
+
+    /// <summary>
+    /// Represents the Mover2D's maxVelocity property.
+    /// </summary>
+    private SerializedProperty maxVelocityXProperty;
+
+    /// <summary>
+    /// Represents the Mover2D's rb2D property.
+    /// </summary>
+    private SerializedProperty rb2DProperty;
+
+    /// <summary>
+    /// Represents the Mover2D's useAcceleration property.
+    /// </summary>
+    private SerializedProperty useAccelerationProperty;
+
+    /// <summary>
+    /// Represents the Mover2D's useDeceleration property.
+    /// </summary>
+    private SerializedProperty useDecelerationProperty;
+
+    /// <summary>
+    /// Represents the Mover2D's wallSensorLeft property.
+    /// </summary>
+    private SerializedProperty wallSensorLeftProperty;
+
+    /// <summary>
+    /// Represents the Mover2D's wallSensorRight property.
+    /// </summary>
+    private SerializedProperty wallSensorRightProperty;
+
+    /// <summary>
+    /// Should info be displayed in the editor?
+    /// </summary>
+    private static bool showInfo = true;
+
+    /// <summary>
+    /// Should jump parameter presets be displayed in the editor?
+    /// </summary>
+    private static bool showPresets = false;
+
+    /// <summary>
+    /// Should testing controls be displayed in the editor?
+    /// </summary>
+    private static bool showTesting = false;
+
+    #region Editor Methods
+    private void OnEnable()
+    {
+        accelerationProperty = serializedObject.FindProperty("acceleration");
+
+        currentVelocityXProperty = 
+            serializedObject.FindProperty("currentVelocityX");
+
+        decelerationProperty = serializedObject.FindProperty("deceleration");
+        maxVelocityXProperty = serializedObject.FindProperty("maxVelocityX");
+
+        rb2DProperty = serializedObject.FindProperty("rb2D");
+        useAccelerationProperty = 
+            serializedObject.FindProperty("useAcceleration");
+
+        useDecelerationProperty = 
+            serializedObject.FindProperty("useDeceleration");
+
+        wallSensorLeftProperty = 
+            serializedObject.FindProperty("wallSensorLeft");
+
+        wallSensorRightProperty = 
+            serializedObject.FindProperty("wallSensorRight");
+    }
+
+    public override void OnInspectorGUI()
+    {
+        Mover2D mover2D = target as Mover2D;
+
+        // Displays the script name at the top of the inspector GUI, which
+        // mimics Unity-standard format.
+        using (new EditorGUI.DisabledScope(true))
+            EditorGUILayout.ObjectField("Script",
+            MonoScript.FromMonoBehaviour((MonoBehaviour)target),
+            GetType(), false);
+
+        DrawComponentReferences();
+
+        EditorGUILayout.Space();
+
+        DrawVelocityParams();
+
+        EditorGUILayout.Space();
+
+        DrawAccelDecelParams();
+
+        EditorGUILayout.Space();
+        showPresets = EditorGUILayout.Foldout(showPresets, "Presets");
+        if (showPresets)
+        {
+            DrawPresets();
+        }
+
+        showTesting = EditorGUILayout.Foldout(showTesting,
+            "Editor Testing");
+        if (showTesting)
+        {
+            DrawTesting(mover2D);
+        }
+
+        showInfo = EditorGUILayout.Foldout(showInfo, "Info");
+        if (showInfo)
+        {
+            DrawInfo();
+        }
+
+        serializedObject.ApplyModifiedProperties();
+    }
+    #endregion
+
+    /// <summary>
+    /// Draws the Acceleration/Deceleration Parameters section of the cutom 
+    /// editor window.
+    /// </summary>
+    private void DrawAccelDecelParams()
+    {
+        EditorGUILayout.LabelField("Acceleration/Deceleration Parameters",
+                    EditorStyles.boldLabel);
+
+        EditorGUILayout.PropertyField(useAccelerationProperty,
+            new GUIContent("Use Acceleration", 
+            "Should this Mover2D approach max velocity over time?"));
+
+        if (useAccelerationProperty.boolValue)
+        {
+            EditorGUILayout.PropertyField(accelerationProperty,
+                new GUIContent("Acceleration", 
+                "At which rate should this Mover2D approach max velocity?"));
+        }
+
+        EditorGUILayout.PropertyField(useDecelerationProperty,
+            new GUIContent("Use Deceleration", 
+            "Should this Mover2D approach a velocity of 0 over time?"));
+
+        if (useDecelerationProperty.boolValue)
+        {
+            EditorGUILayout.PropertyField(decelerationProperty,
+                new GUIContent("Deceleration", 
+                "At which rate should this Mover2D approach a velocity of 0?"));
+        }
+    }
+
+    /// <summary>
+    /// Draws Component References section of the custom editor window.
+    /// </summary>
+    private void DrawComponentReferences()
+    {
+        EditorGUILayout.LabelField("Component References", 
+            EditorStyles.boldLabel);
+
+        EditorGUILayout.PropertyField(rb2DProperty,
+            new GUIContent("Rb 2D", 
+            "Which Rigidbody2D should this Mover2D affect?"));
+
+        EditorGUILayout.PropertyField(wallSensorLeftProperty,
+            new GUIContent("Wall Sensor Left", 
+            "Which Sensor2D should be responsible for sensing walls " +
+            "to the left?"));
+
+        EditorGUILayout.PropertyField(wallSensorRightProperty,
+            new GUIContent("Wall Sensor Right", 
+            "Which Sensor2D should be responsible for sensing walls " + 
+            "to the right?"));
+    }
+
+    /// <summary>
+    /// Draws the Info section of the custom editor window.
+    /// </summary>
+    private void DrawInfo()
+    {
+        // Current Velocity
+        using (new EditorGUI.DisabledScope(true))
+            EditorGUILayout.PropertyField(currentVelocityXProperty);
+
+        // Acceleration Data
+        if (useAccelerationProperty.boolValue)
+        {
+            float accelTime = 
+                maxVelocityXProperty.floatValue / 
+                accelerationProperty.floatValue;
+            using (new EditorGUI.DisabledScope(true))
+                EditorGUILayout.FloatField("Acceleration Time", accelTime);
+
+            float accelFrames = accelTime / Time.fixedDeltaTime;
+            using (new EditorGUI.DisabledScope(true))
+                EditorGUILayout.FloatField("Acceleration Frames (60fps)",
+                UtilityMethods.StandardizeFrameCount(accelFrames, 60));
+        }
+
+        // Deceleration Data
+        if (useDecelerationProperty.boolValue)
+        {
+            float decelTime = 
+                maxVelocityXProperty.floatValue / 
+                decelerationProperty.floatValue;
+            using (new EditorGUI.DisabledScope(true))
+                EditorGUILayout.FloatField("Deceleration Time", decelTime);
+
+            float decelFrames = decelTime / Time.fixedDeltaTime;
+            using (new EditorGUI.DisabledScope(true))
+                EditorGUILayout.FloatField("Deceleration Frames (60fps)",
+                UtilityMethods.StandardizeFrameCount(decelFrames, 60));
+        }
+    }
+
+    /// <summary>
+    /// Draws the Presets section of the custom editor window.
+    /// </summary>
+    private void DrawPresets()
+    {
+        EditorGUILayout.LabelField("Use these buttons to set movement " +
+            "behaviour to the selected description.");
+
+        if (GUILayout.Button(new GUIContent("Lightweight and Responsive",
+            "i.e. Celeste")))
+        {
+            maxVelocityXProperty.floatValue = 5.625f;
+            useAccelerationProperty.boolValue = true;
+            accelerationProperty.floatValue = 56.25f;
+            useDecelerationProperty.boolValue = true;
+            decelerationProperty.floatValue = 112.5f;
+        }
+
+        if (GUILayout.Button(new GUIContent("Heavyweight and Fast",
+            "i.e. Super Meat Boy")))
+        {
+            maxVelocityXProperty.floatValue = 6.25f;
+            useAccelerationProperty.boolValue = true;
+            accelerationProperty.floatValue = 15.625f;
+            useDecelerationProperty.boolValue = true;
+            decelerationProperty.floatValue = 125.0f;
+        }
+
+        if (GUILayout.Button(new GUIContent("Stiff and Robotic",
+            "i.e. Mega Man 11")))
+        {
+            maxVelocityXProperty.floatValue = 6.25f;
+            useAccelerationProperty.boolValue = true;
+            accelerationProperty.floatValue = 250.0f;
+            useDecelerationProperty.boolValue = true;
+            decelerationProperty.floatValue = 250.0f;
+        }
+
+        if (GUILayout.Button(new GUIContent("Midweight and Slippery",
+            "i.e Super Mario Bros. 3")))
+        {
+            maxVelocityXProperty.floatValue = 6.25f;
+            useAccelerationProperty.boolValue = true;
+            accelerationProperty.floatValue = 27.77777f;
+            useDecelerationProperty.boolValue = true;
+            decelerationProperty.floatValue = 18.5185f;
+        }
+    }
+
+    /// <summary>
+    /// Draws the Testing section of the custom editor window.
+    /// </summary>
+    private static void DrawTesting(Mover2D mover2D)
+    {
+        EditorGUILayout.LabelField("While in Play Mode, use these " +
+            "buttons to test movement behaviour.");
+        if (GUILayout.Button("Set Move Input to 1"))
+        {
+            if (Application.isPlaying)
+            {
+                mover2D.MoveInput = 1;
+            }
+        }
+        if (GUILayout.Button("Set Move Input to -1"))
+        {
+            if (Application.isPlaying)
+            {
+                mover2D.MoveInput = -1;
+            }
+        }
+        if (GUILayout.Button("Set Move Input to 0"))
+        {
+            if (Application.isPlaying)
+            {
+                mover2D.MoveInput = 0;
+            }
+        }
+    }
+
+    /// <summary>
+    /// Draws Velocity Parameters section of the custom editor window.
+    /// </summary>
+    private void DrawVelocityParams()
+    {
+        EditorGUILayout.LabelField("Velocity Parameters", 
+            EditorStyles.boldLabel);
+
+        EditorGUILayout.PropertyField(maxVelocityXProperty,
+            new GUIContent("Max Velocity X", 
+            "What is the fastest velocity at which this Mover2D can travel?"));
+    }
+}
+

--- a/ShooterCrateBoxProject/Assets/Scripts/Editor/Mover2DEditor.cs.meta
+++ b/ShooterCrateBoxProject/Assets/Scripts/Editor/Mover2DEditor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ad18d9139bfaa084d98a2b444ab1f600
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ShooterCrateBoxProject/Assets/Scripts/Movement/Jumper2D.cs
+++ b/ShooterCrateBoxProject/Assets/Scripts/Movement/Jumper2D.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
@@ -9,17 +7,191 @@ using UnityEngine;
 /// </summary>
 public class Jumper2D : MonoBehaviour
 {
+    /// <summary>
+    /// Force applied each frame to cancel a jump with variable height.
+    /// </summary>
+    [SerializeField] private float cancelRate = 100.0f;
+
+    /// <summary>
+    /// Gravity scale applied to the Rigidbody2D component. Use this parameter
+    /// instead of editing the Rigidbody2D's gravity scale property directly.
+    /// </summary>
+    [SerializeField] private float gravityScale = 1.0f;
+
+    /// <summary>
+    /// Sensor2D responsible for checking the grounded state of the object.
+    /// </summary>
+    [SerializeField] private Sensor2D groundSensor;
+
+    /// <summary>
+    /// Sensor2D responsible for checking collisions above the object
+    /// </summary>
+    [SerializeField] private Sensor2D headSensor;
+
+    /// <summary>
+    /// Tracks how many jumps the object has performed without grounding.
+    /// </summary>
+    [SerializeField] private int jumpCount = 0;
+
+    /// <summary>
+    /// Force required to reach maximumJumpHeight given a gravitational
+    /// constant and gravityScale.
+    /// </summary>
+    [SerializeField] private float jumpForce = 0.0f;
+
+    /// <summary>
+    /// Maximum time button can be held for variable jump height.
+    /// </summary>
+    [SerializeField] private float jumpWindowTime = 0.3f;
+
+    /// <summary>
+    /// Maximum height to which the object can jump.
+    /// </summary>
+    [SerializeField] private float maxJumpHeight = 5.0f;
+
+    /// <summary>
+    /// Can the object jump once it is in the air?
+    /// </summary>
+    [SerializeField] private bool multiJump = false;
+
+    /// <summary>
+    /// Rigidbody2D component to be affected by this Jumper2D.
+    /// </summary>
     [SerializeField] private Rigidbody2D rb2D;
-    
-    // Start is called before the first frame update
-    void Start()
+
+    /// <summary>
+    /// How many times can the object jump without grounding?
+    /// </summary>
+    [SerializeField] private int totalJumps = 1;
+
+    /// <summary>
+    /// If true, final jump height is higher the longer the player holds down 
+    /// jump input, clamped at maxJumpHeight. If false, player always jumps to
+    /// maxJumpHeight when jump input is pressed.
+    /// </summary>
+    [SerializeField] private bool variableJump = false;
+
+    /// <summary>
+    /// Determines if this object is currently jumping.
+    /// </summary>
+    private bool isJumping = false;
+
+    /// <summary>
+    /// Determines if this object has recieved a signal to cancel a jump.
+    /// </summary>
+    private bool isJumpCancelled = false;
+
+    /// <summary>
+    /// Time elapsed since jump began.
+    /// </summary>
+    private float jumpTime = 0.0f;
+
+    #region MonoBehaviour Methods
+    private void Awake()
     {
-        
+        rb2D.gravityScale = gravityScale;
     }
 
-    // Update is called once per frame
-    void Update()
+    private void OnEnable()
     {
-        
+        groundSensor.sensorStateChanged += ResetJumpCount;
+        headSensor.sensorStateChanged += StopJump;
+    }
+
+    private void Update()
+    {
+        if (variableJump && isJumping)
+        {
+            jumpTime += Time.deltaTime;
+            if (jumpTime > jumpWindowTime)
+            {
+                isJumping = false;
+            }
+        }
+    }
+
+    private void FixedUpdate()
+    {
+        if (isJumpCancelled && isJumping && rb2D.velocity.y > 0)
+        {
+            if (cancelRate != 0)
+            {
+                rb2D.AddForce(Vector2.down * cancelRate);
+            }
+            else
+            {
+                rb2D.velocity = new Vector2(rb2D.velocity.x, 0.0f);
+            }
+        }
+    }
+
+    private void OnDisable()
+    {
+        groundSensor.sensorStateChanged -= ResetJumpCount;
+        headSensor.sensorStateChanged -= StopJump;
+    }
+    #endregion
+
+    /// <summary>
+    /// Makes the object jump.
+    /// </summary>
+    public void Jump()
+    {
+        if (groundSensor.Active || (multiJump && jumpCount < totalJumps))
+        {
+            if (!groundSensor.Active)
+            {
+                // For a multi jump, reset y velocity before mid air jump.
+                rb2D.velocity = new Vector2(rb2D.velocity.x, 0.0f);
+            }
+
+            rb2D.gravityScale = gravityScale;
+            float gravity = Physics2D.gravity.y * gravityScale;
+            jumpForce = Mathf.Sqrt(-2 * maxJumpHeight * gravity);
+            rb2D.AddForce(new Vector2(0, jumpForce), ForceMode2D.Impulse);
+
+            if (multiJump)
+            {
+                jumpCount += 1;
+            }
+
+            if (variableJump)
+            {
+                isJumping = true;
+                isJumpCancelled = false;
+                jumpTime = 0.0f;
+            }
+        }
+    }
+
+    /// <summary>
+    /// "Cancels" a variable jump, best utilized when the player releases the
+    /// jump input.
+    /// </summary>
+    public void StopVariableJump()
+    {
+        if (variableJump)
+        {
+            StopJump();
+        }
+    }
+
+    /// <summary>
+    /// Resets the number of jumps the character has performed.
+    /// </summary>
+    private void ResetJumpCount()
+    {
+        if (groundSensor.Active && multiJump)
+        {
+            jumpCount = 0;
+        }
+    }
+
+    /// <summary>
+    /// Stops a jump.
+    /// </summary>
+    private void StopJump()
+    {
+        isJumpCancelled = true;
     }
 }

--- a/ShooterCrateBoxProject/Assets/Scripts/Movement/Mover2D.cs
+++ b/ShooterCrateBoxProject/Assets/Scripts/Movement/Mover2D.cs
@@ -1,5 +1,3 @@
-using System.Collections;
-using System.Collections.Generic;
 using UnityEngine;
 
 /// <summary>
@@ -9,17 +7,149 @@ using UnityEngine;
 /// </summary>
 public class Mover2D : MonoBehaviour
 {
+    /// <summary>
+    /// Rate at which x velocity moves toward maxVelocityX.
+    /// </summary>
+    [SerializeField] private float acceleration = 10.0f;
+
+    /// <summary>
+    /// Current velocity of the Mover2D.
+    /// </summary>
+    [SerializeField] private float currentVelocityX = 0;
+
+    /// <summary>
+    /// Rate at which x velocity moves toward 0.0.
+    /// </summary>
+    [SerializeField] private float deceleration = 10.0f;
+
+    /// <summary>
+    /// Maximum X velocity of this Mover2D.
+    /// </summary>
+    [SerializeField] private float maxVelocityX = 5.0f;
+
+    /// <summary>
+    /// Rigidbody2D component to be affected by this Mover2D.
+    /// </summary>
     [SerializeField] private Rigidbody2D rb2D;
 
-    // Start is called before the first frame update
-    void Start()
+    /// <summary>
+    /// Does this Mover2D accelerate to approach maxVelocityX?
+    /// </summary>
+    [SerializeField] private bool useAcceleration;
+
+    /// <summary>
+    /// Does this Mover2D decelerate to approach 0.0 velocity X?
+    /// </summary>
+    [SerializeField] private bool useDeceleration;
+
+    /// <summary>
+    /// Sensor2D responsible for checking if the Mover2D is against a wall to
+    /// its left.
+    /// </summary>
+    [SerializeField] private Sensor2D wallSensorLeft;
+
+    /// <summary>
+    /// Sensor2D responsible for checking if the Mover2D is against a wall to
+    /// its right.
+    /// </summary>
+    [SerializeField] private Sensor2D wallSensorRight;
+
+    /// <summary>
+    /// Movement direction based on controller input.
+    /// </summary>
+    private float moveInput;
+
+    /// <summary>
+    /// Movement direction based on controller input.
+    /// </summary>
+    public float MoveInput
     {
-        
+        get
+        {
+            return moveInput;
+        }
+        set
+        {
+            moveInput = value;
+            currentVelocityX = rb2D.velocity.x;
+        }
     }
 
-    // Update is called once per frame
-    void Update()
+    #region Monobehaviour Methods
+    private void FixedUpdate()
     {
-        
+        CalculateNewXVelocity();
+        rb2D.velocity = new Vector2(currentVelocityX, rb2D.velocity.y);
+    }
+    #endregion
+
+    /// <summary>
+    /// Calculates current velocity based on MoveInput and whether the Mover2D 
+    /// uses acceleration and/or deceleration.
+    /// </summary>
+    private void CalculateNewXVelocity()
+    {
+        if (MoveInput != 0)
+        {
+            // If the Mover2D is moving into a wall, set its velocity to 0. This
+            // prevents unintended wall sticking.
+            if ((MoveInput == -1 && wallSensorLeft.Active) ||
+                (MoveInput == 1 && wallSensorRight.Active))
+            {
+                currentVelocityX = 0;
+                return;
+            }
+
+            if (useDeceleration)
+            {
+                if (MoveInput == 1 && currentVelocityX < 0.0f)
+                {
+                    currentVelocityX += deceleration * Time.fixedDeltaTime;
+                }
+                else if (MoveInput == -1 && currentVelocityX > 0.0f)
+                {
+                    currentVelocityX -= deceleration * Time.fixedDeltaTime;
+                }
+            }
+
+            if (useAcceleration)
+            {
+                if (MoveInput == 1 && currentVelocityX >= 0.0f && currentVelocityX < maxVelocityX)
+                {
+                    currentVelocityX += acceleration * Time.fixedDeltaTime;
+                }
+                else if (MoveInput == -1 && currentVelocityX <= 0.0f && currentVelocityX > -maxVelocityX)
+                {
+                    currentVelocityX -= acceleration * Time.fixedDeltaTime;
+                }
+            }
+            else
+            {
+                currentVelocityX = maxVelocityX * MoveInput;
+            }
+
+        }
+        else
+        {
+            if (useDeceleration)
+            {
+                if (currentVelocityX > deceleration * Time.fixedDeltaTime)
+                {
+                    currentVelocityX -= deceleration * Time.fixedDeltaTime;
+                }
+                else if (currentVelocityX < -deceleration * Time.fixedDeltaTime)
+                {
+                    currentVelocityX += deceleration * Time.fixedDeltaTime;
+                }
+                else
+                {
+                    currentVelocityX = 0;
+                }
+            }
+            else
+            {
+                currentVelocityX = 0;
+            }
+        }
     }
 }

--- a/ShooterCrateBoxProject/Assets/Scripts/Utilities/UtilityMethods.cs
+++ b/ShooterCrateBoxProject/Assets/Scripts/Utilities/UtilityMethods.cs
@@ -1,0 +1,44 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// A collection of miscellaneous, static helper functions.
+/// </summary>
+public static class UtilityMethods
+{
+    #region Frame Count Methods
+    /// <summary>
+    /// Returns a float representing the frame count standardized to the 
+    /// referenceFPS. Assumes the raw frame count is derived from the project's
+    /// fixedDeltaTime parameter.
+    /// </summary>
+    /// <param name="frameCount">Frame count to standardize to the 
+    /// referenceFPS.</param>
+    /// <param name="referenceFPS">The frames-per-second to standardize the
+    /// frame count to.</param>
+    /// <returns> A float representing the frame count standardized to the 
+    /// referenceFPS.</returns>
+    public static float StandardizeFrameCount(float frameCount, int referenceFPS)
+    {
+        return frameCount / ((1 / Time.fixedDeltaTime) / referenceFPS);
+    }
+
+    /// <summary>
+    /// Returns a float representing the frame count standardized to the 
+    /// referenceFPS.
+    /// </summary>
+    /// <param name="frameCount">Frame count to standardize to the 
+    /// referenceFPS.</param>
+    /// <param name="rawFPS">The frames-per-second at which frameCount was
+    /// calculated.</param>
+    /// <param name="referenceFPS">The frames-per-second to standardize the
+    /// frame count to.</param>
+    /// <returns> A float representing the frame count standardized to the 
+    /// referenceFPS.</returns>
+    public static float StandardizeFrameCount(float frameCount, int rawFPS, int referenceFPS)
+    {
+        return frameCount / ((1 / (1 / rawFPS)) / referenceFPS);
+    }
+    #endregion
+}

--- a/ShooterCrateBoxProject/Assets/Scripts/Utilities/UtilityMethods.cs.meta
+++ b/ShooterCrateBoxProject/Assets/Scripts/Utilities/UtilityMethods.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 822981ddf3add754faf296725c381fa0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ShooterCrateBoxProject/Assets/Settings/PlayerControls.inputactions
+++ b/ShooterCrateBoxProject/Assets/Settings/PlayerControls.inputactions
@@ -37,7 +37,29 @@
                 {
                     "name": "",
                     "id": "81c7804d-1d55-4ea1-b1e6-97b40cfbc10f",
-                    "path": "",
+                    "path": "<Keyboard>/space",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "46994bdd-c0c0-4491-8ad2-97095a068d48",
+                    "path": "<Keyboard>/w",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "Jump",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "e212a98f-6148-4897-86de-1ca3644731ba",
+                    "path": "<Keyboard>/upArrow",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -59,7 +81,7 @@
                 {
                     "name": "negative",
                     "id": "68b71f90-b0fc-4ab5-b6ef-3663700dc2bd",
-                    "path": "",
+                    "path": "<Keyboard>/a",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -70,7 +92,7 @@
                 {
                     "name": "positive",
                     "id": "9c9765da-0f14-4311-bc55-9ceecfc7c6cb",
-                    "path": "",
+                    "path": "<Keyboard>/d",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -92,7 +114,7 @@
                 {
                     "name": "negative",
                     "id": "a654c97c-9382-4672-bbc8-28cc8fbb0aa4",
-                    "path": "",
+                    "path": "<Keyboard>/leftArrow",
                     "interactions": "",
                     "processors": "",
                     "groups": "",
@@ -103,7 +125,7 @@
                 {
                     "name": "positive",
                     "id": "0ff12896-efbe-4dd5-a484-d740a467ebc7",
-                    "path": "",
+                    "path": "<Keyboard>/rightArrow",
                     "interactions": "",
                     "processors": "",
                     "groups": "",

--- a/ShooterCrateBoxProject/UserSettings/Layouts/default-2021.dwlt
+++ b/ShooterCrateBoxProject/UserSettings/Layouts/default-2021.dwlt
@@ -16,10 +16,10 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 43.2
-    width: 1024
-    height: 492.80002
+    width: 3072
+    height: 1644.8
   m_ShowMode: 4
-  m_Title: Project
+  m_Title: Game
   m_RootView: {fileID: 4}
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
@@ -40,11 +40,11 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 266.4
-    width: 161.59998
-    height: 176.40002
-  m_MinSize: {x: 101, y: 121}
-  m_MaxSize: {x: 4001, y: 4021}
+    y: 960
+    width: 484.80005
+    height: 634.80005
+  m_MinSize: {x: 100, y: 100}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 16}
   m_Panes:
   - {fileID: 16}
@@ -67,14 +67,14 @@ MonoBehaviour:
   - {fileID: 2}
   m_Position:
     serializedVersion: 2
-    x: 862.4
+    x: 2587.2
     y: 0
-    width: 161.59998
-    height: 442.80002
+    width: 484.80005
+    height: 1594.8
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 49
+  controlID: 151
 --- !u!114 &4
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -95,8 +95,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1024
-    height: 492.80002
+    width: 3072
+    height: 1644.8
   m_MinSize: {x: 875, y: 300}
   m_MaxSize: {x: 10000, y: 10000}
   m_UseTopView: 1
@@ -120,7 +120,7 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 1024
+    width: 3072
     height: 30
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
@@ -141,8 +141,8 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 472.80002
-    width: 1024
+    y: 1624.8
+    width: 3072
     height: 20
   m_MinSize: {x: 0, y: 0}
   m_MaxSize: {x: 0, y: 0}
@@ -166,12 +166,12 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 30
-    width: 1024
-    height: 442.80002
+    width: 3072
+    height: 1594.8
   m_MinSize: {x: 300, y: 200}
   m_MaxSize: {x: 24288, y: 16192}
   vertical: 0
-  controlID: 48
+  controlID: 150
 --- !u!114 &8
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -189,8 +189,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 702.4
-    height: 442.80002
+    width: 2107.2
+    height: 1594.8
   m_MinSize: {x: 201, y: 221}
   m_MaxSize: {x: 4001, y: 4021}
   m_ActualView: {fileID: 15}
@@ -216,14 +216,14 @@ MonoBehaviour:
   - {fileID: 11}
   m_Position:
     serializedVersion: 2
-    x: 702.4
+    x: 2107.2
     y: 0
-    width: 160
-    height: 442.80002
+    width: 480
+    height: 1594.8
   m_MinSize: {x: 100, y: 200}
   m_MaxSize: {x: 8096, y: 16192}
   vertical: 1
-  controlID: 99
+  controlID: 116
 --- !u!114 &10
 MonoBehaviour:
   m_ObjectHideFlags: 52
@@ -241,8 +241,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 160
-    height: 266.4
+    width: 480
+    height: 960
   m_MinSize: {x: 202, y: 221}
   m_MaxSize: {x: 4002, y: 4021}
   m_ActualView: {fileID: 17}
@@ -266,9 +266,9 @@ MonoBehaviour:
   m_Position:
     serializedVersion: 2
     x: 0
-    y: 266.4
-    width: 160
-    height: 176.40002
+    y: 960
+    width: 480
+    height: 634.80005
   m_MinSize: {x: 232, y: 271}
   m_MaxSize: {x: 10002, y: 10021}
   m_ActualView: {fileID: 18}
@@ -293,10 +293,10 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 0
-    width: 161.59998
-    height: 266.4
-  m_MinSize: {x: 276, y: 71}
-  m_MaxSize: {x: 4001, y: 4021}
+    width: 484.80005
+    height: 960
+  m_MinSize: {x: 275, y: 50}
+  m_MaxSize: {x: 4000, y: 4000}
   m_ActualView: {fileID: 19}
   m_Panes:
   - {fileID: 19}
@@ -392,7 +392,7 @@ MonoBehaviour:
     m_HSlider: 0
     m_VSlider: 0
     m_IgnoreScrollWheelUntilClicked: 0
-    m_EnableMouseInput: 1
+    m_EnableMouseInput: 0
     m_EnableSliderZoomHorizontal: 0
     m_EnableSliderZoomVertical: 0
     m_UniformScale: 1
@@ -445,8 +445,8 @@ MonoBehaviour:
     serializedVersion: 2
     x: 0
     y: 73.6
-    width: 701.4
-    height: 421.80002
+    width: 2106.2
+    height: 1573.8
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -456,8 +456,8 @@ MonoBehaviour:
       floating: 0
       collapsed: 0
       displayed: 1
-      snapOffset: {x: 0, y: 0}
-      snapOffsetDelta: {x: -100, y: -25.600006}
+      snapOffset: {x: -100, y: -25.599976}
+      snapOffsetDelta: {x: 0, y: 0}
       snapCorner: 3
       id: Tool Settings
       index: 0
@@ -478,7 +478,7 @@ MonoBehaviour:
       floating: 0
       collapsed: 0
       displayed: 1
-      snapOffset: {x: 0, y: 0}
+      snapOffset: {x: 0, y: 24.8}
       snapOffsetDelta: {x: 0, y: 0}
       snapCorner: 0
       id: unity-scene-view-toolbar
@@ -670,9 +670,9 @@ MonoBehaviour:
   m_PlayAudio: 0
   m_AudioPlay: 0
   m_Position:
-    m_Target: {x: -0.6318389, y: -0.2604112, z: -4.246991}
+    m_Target: {x: -0.009835552, y: 0.12256381, z: 0.07831604}
     speed: 2
-    m_Value: {x: -0.6318389, y: -0.2604112, z: -4.246991}
+    m_Value: {x: -0.009835552, y: 0.12256381, z: 0.07831604}
   m_RenderMode: 0
   m_CameraMode:
     drawMode: 0
@@ -723,9 +723,9 @@ MonoBehaviour:
     speed: 2
     m_Value: {x: 0, y: 0, z: 0, w: 1}
   m_Size:
-    m_Target: 5.8949523
+    m_Target: 1.5140433
     speed: 2
-    m_Value: 5.8949523
+    m_Value: 1.5140433
   m_Ortho:
     m_Target: 1
     speed: 2
@@ -770,10 +770,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 862.4
-    y: 340
-    width: 160.59998
-    height: 155.40002
+    x: 2587.2
+    y: 1033.6
+    width: 483.80005
+    height: 613.80005
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -798,10 +798,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 702.4
+    x: 2107.2
     y: 73.6
-    width: 158
-    height: 245.4
+    width: 478
+    height: 939
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -809,9 +809,9 @@ MonoBehaviour:
   m_SceneHierarchy:
     m_TreeViewState:
       scrollPos: {x: 0, y: 0}
-      m_SelectedIDs: 00710000
+      m_SelectedIDs: 60190000
       m_LastClickedID: 0
-      m_ExpandedIDs: 0afbffff
+      m_ExpandedIDs: ccfaffff0afbffff
       m_RenameOverlay:
         m_UserAcceptedRename: 0
         m_Name: 
@@ -855,10 +855,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 702.4
-    y: 340
-    width: 158
-    height: 155.40002
+    x: 2107.2
+    y: 1033.6
+    width: 478
+    height: 613.80005
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default
@@ -876,7 +876,7 @@ MonoBehaviour:
     m_SkipHidden: 0
     m_SearchArea: 1
     m_Folders:
-    - Assets/Scripts
+    - Assets/Scripts/Control
     m_Globs: []
     m_OriginalText: 
   m_ViewMode: 0
@@ -890,7 +890,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: f8680000
     m_LastClickedID: 26872
-    m_ExpandedIDs: 00000000ca6e0000
+    m_ExpandedIDs: 00000000d8720000da720000dc720000de720000e0720000e2720000e4720000e6720000e8720000ea720000ec720000ee720000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -918,7 +918,7 @@ MonoBehaviour:
     scrollPos: {x: 0, y: 0}
     m_SelectedIDs: 
     m_LastClickedID: 0
-    m_ExpandedIDs: ffffffff00000000ca6e0000ae70000006710000
+    m_ExpandedIDs: ffffffff00000000d8720000da720000dc720000de720000e0720000e2720000e4720000e6720000e8720000ea720000ec720000ee720000cc740000da740000dc740000e0740000
     m_RenameOverlay:
       m_UserAcceptedRename: 0
       m_Name: 
@@ -994,10 +994,10 @@ MonoBehaviour:
     m_Tooltip: 
   m_Pos:
     serializedVersion: 2
-    x: 862.4
+    x: 2587.2
     y: 73.6
-    width: 160.59998
-    height: 245.4
+    width: 483.80005
+    height: 939
   m_ViewDataDictionary: {fileID: 0}
   m_OverlayCanvas:
     m_LastAppliedPresetName: Default


### PR DESCRIPTION
Complete implementation of basic player movement. The user may now move the player left and right, as well as make the player jump (with a variable jump height).

Additional Notes:
+ CratePickup prefab was moved to the Pickup layer, and its collider has been changed to a trigger. The player will no longer stop moving when it collides with this object. This functionality will be revisited when Pickups are fully implemented.
+ The Mover2D script has been removed from the EnemyBase prefab at this time, as it was causing exceptions and enemies are not the focus of this module.